### PR TITLE
[12] Update NiceText to support AttributedString

### DIFF
--- a/NiceComponentsExample/NiceComponentsExample.xcodeproj/project.pbxproj
+++ b/NiceComponentsExample/NiceComponentsExample.xcodeproj/project.pbxproj
@@ -327,7 +327,7 @@
 				DEVELOPMENT_TEAM = GH868RP95T;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = NiceComponentsExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -350,7 +350,7 @@
 				DEVELOPMENT_TEAM = GH868RP95T;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = NiceComponentsExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/NiceComponentsExample/NiceComponentsExample/View/AllComponentsView.swift
+++ b/NiceComponentsExample/NiceComponentsExample/View/AllComponentsView.swift
@@ -18,6 +18,13 @@ struct AllComponentsView: View {
                     ScreenTitle("Screen Title")
                     SectionTitle("Section Title")
                     ItemTitle("Item Title")
+                    ItemTitle("Attributed Item Title") { string  in
+                        if let range = string.range(of: "Attributed") {
+                            string[range].foregroundColor = .red
+                            string[range].underlineStyle = .single
+                            string[range].font = .custom(Config.current.detailTextStyle)
+                        }
+                    }
                 }
 
                 ThemedDivider()

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "NiceComponents",
     platforms: [
-        .iOS(.v14),
+        .iOS("15.0"),
         .macOS(.v10_15)
     ],
     products: [

--- a/Sources/NiceComponents/Helper/Font+TypeStyle.swift
+++ b/Sources/NiceComponents/Helper/Font+TypeStyle.swift
@@ -1,0 +1,18 @@
+//
+//  Font+TypeStyle.swift
+//  
+//
+//  Created by Alejandro Zielinsky on 2022-06-30.
+//
+
+import SwiftUI
+
+public extension Font {
+    static func custom(_ typeStyle: TypeStyle) -> Font {
+        if let fontName = typeStyle.theme.name {
+            return .custom(fontName, size: typeStyle.theme.size)
+        } else {
+            return .system(size: typeStyle.theme.size, weight: typeStyle.theme.weight ?? .regular)
+        }
+    }
+}

--- a/Sources/NiceComponents/Text/BodyText.swift
+++ b/Sources/NiceComponents/Text/BodyText.swift
@@ -8,14 +8,14 @@
 import SwiftUI
 
 public struct BodyText: NiceText {
-    public let text: String
+    public let text: AttributedString
     public let style: TypeStyle
 
     public static var defaultStyle: TypeStyle {
         Config.current.bodyTextStyle
     }
 
-    public init(_ text: String, style: TypeStyle? = nil) {
+    public init(_ text: AttributedString, style: TypeStyle? = nil) {
         self.text = text
         self.style = style ?? Self.defaultStyle
     }

--- a/Sources/NiceComponents/Text/DetailText.swift
+++ b/Sources/NiceComponents/Text/DetailText.swift
@@ -8,14 +8,14 @@
 import SwiftUI
 
 public struct DetailText: NiceText {
-    public let text: String
+    public let text: AttributedString
     public let style: TypeStyle
 
     public static var defaultStyle: TypeStyle {
         Config.current.detailTextStyle
     }
 
-    public init(_ text: String, style: TypeStyle? = nil) {
+    public init(_ text: AttributedString, style: TypeStyle? = nil) {
         self.text = text
         self.style = style ?? Self.defaultStyle
     }

--- a/Sources/NiceComponents/Theme/NiceText.swift
+++ b/Sources/NiceComponents/Theme/NiceText.swift
@@ -9,16 +9,21 @@ import SwiftUI
 
 public protocol NiceText: View {
 
-    var text: String { get }
+    var text: AttributedString { get }
     var style: TypeStyle { get }
     static var defaultStyle: TypeStyle { get }
+
+    init(_ attributedText: AttributedString, style: TypeStyle?)
 
     init(_ text: String, style: TypeStyle?)
 
     init(_ text: String, color: Color?, size: CGFloat?, lineLimit: Int?)
+
+    init(_ text: String, configure: (inout AttributedString) -> Void)
 }
 
 public extension NiceText {
+
     init(
         _ text: String,
         color: Color? = nil,
@@ -33,6 +38,16 @@ public extension NiceText {
                 lineLimit: lineLimit
             )
         )
+    }
+
+    init(_ text: String, style: TypeStyle?) {
+        self.init(AttributedString(text), style: style)
+    }
+
+    init(_ text: String, configure: (inout AttributedString) -> Void) {
+        var attributedString = AttributedString(text)
+        configure(&attributedString)
+        self.init(attributedString, style: Self.defaultStyle)
     }
 }
 

--- a/Sources/NiceComponents/Title/ItemTitle.swift
+++ b/Sources/NiceComponents/Title/ItemTitle.swift
@@ -9,14 +9,14 @@ import SwiftUI
 
 public struct ItemTitle: NiceText {
 
-    public let text: String
+    public let text: AttributedString
     public let style: TypeStyle
 
     static public var defaultStyle: TypeStyle {
         Config.current.itemTitleStyle
     }
 
-    public init(_ text: String, style: TypeStyle? = nil) {
+    public init(_ text: AttributedString, style: TypeStyle? = nil) {
         self.text = text
         self.style = style ?? Self.defaultStyle
     }

--- a/Sources/NiceComponents/Title/ScreenTitle.swift
+++ b/Sources/NiceComponents/Title/ScreenTitle.swift
@@ -8,15 +8,14 @@
 import SwiftUI
 
 public struct ScreenTitle: NiceText {
-
-    public let text: String
+    public let text: AttributedString
     public let style: TypeStyle
 
     public static var defaultStyle: TypeStyle {
         Config.current.screenTitleStyle
     }
 
-    public init(_ text: String, style: TypeStyle? = nil) {
+    public init(_ text: AttributedString, style: TypeStyle? = nil) {
         self.text = text
         self.style = style ?? Self.defaultStyle
     }

--- a/Sources/NiceComponents/Title/SectionTitle.swift
+++ b/Sources/NiceComponents/Title/SectionTitle.swift
@@ -9,14 +9,14 @@ import SwiftUI
 
 public struct SectionTitle: NiceText {
 
-    public var text: String
+    public var text: AttributedString
     public let style: TypeStyle
 
     public static var defaultStyle: TypeStyle {
         Config.current.sectionTitleStyle
     }
 
-    public init(_ text: String, style: TypeStyle? = nil) {
+    public init(_ text: AttributedString, style: TypeStyle? = nil) {
         self.text = text
         self.style = style ?? Self.defaultStyle
     }


### PR DESCRIPTION
### For #12 

This PR adds support for AttributedStrings in Text components and in doing so increments the min version of this library to iOS 15. 

#### Usage: 

Pass in a config block `(inout AttributedString) -> Void` to the init of a Text component to 
configure its attributes. This makes attributing strings much cleaner/easier to use  than NSAttributedStrings.

``` Swift
ItemTitle("Attributed Item Title") { string  in
    if let range = string.range(of: "Attributed") {
        string[range].foregroundColor = .red
        string[range].underlineStyle = .single
        string[range].font = .custom(Config.current.detailTextStyle)
    }
}
```

Above code sample also includes a new helper for Font initialization that takes in a TypeStyle. 

![Simulator Screen Shot - iPhone 12 - 2022-07-07 at 14 29 04](https://user-images.githubusercontent.com/17748596/177876048-76902b68-25dd-4a92-b3d4-8348bdfee61b.png)
 