### PR TITLE
[33] ResizableImage improvement

### DIFF
--- a/NiceComponentsExample/NiceComponentsExample.xcodeproj/project.pbxproj
+++ b/NiceComponentsExample/NiceComponentsExample.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		C6CD255825D6F01C008026D5 /* AllComponentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6CD255725D6F01C008026D5 /* AllComponentsView.swift */; };
 		C6CD255D25D6F0B1008026D5 /* SampleSignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6CD255C25D6F0B1008026D5 /* SampleSignInView.swift */; };
 		D204537028860ABC00174C13 /* NiceButtonExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D204536F28860ABC00174C13 /* NiceButtonExampleView.swift */; };
+		D2F8201228A464AA008BCF68 /* AsyncImageExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F8201128A464AA008BCF68 /* AsyncImageExampleView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -36,6 +37,7 @@
 		C6CD255725D6F01C008026D5 /* AllComponentsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AllComponentsView.swift; sourceTree = "<group>"; };
 		C6CD255C25D6F0B1008026D5 /* SampleSignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleSignInView.swift; sourceTree = "<group>"; };
 		D204536F28860ABC00174C13 /* NiceButtonExampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NiceButtonExampleView.swift; sourceTree = "<group>"; };
+		D2F8201128A464AA008BCF68 /* AsyncImageExampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncImageExampleView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -114,6 +116,7 @@
 				C6CD255C25D6F0B1008026D5 /* SampleSignInView.swift */,
 				C65289F226CF0DFF009D486B /* StatefulExampleView.swift */,
 				D204536F28860ABC00174C13 /* NiceButtonExampleView.swift */,
+				D2F8201128A464AA008BCF68 /* AsyncImageExampleView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -198,6 +201,7 @@
 				C614E74226E12DAB00F7F87C /* Theme.swift in Sources */,
 				C6CD255D25D6F0B1008026D5 /* SampleSignInView.swift in Sources */,
 				C6CD255825D6F01C008026D5 /* AllComponentsView.swift in Sources */,
+				D2F8201228A464AA008BCF68 /* AsyncImageExampleView.swift in Sources */,
 				D204537028860ABC00174C13 /* NiceButtonExampleView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/NiceComponentsExample/NiceComponentsExample/ContentView.swift
+++ b/NiceComponentsExample/NiceComponentsExample/ContentView.swift
@@ -18,6 +18,9 @@ struct ContentView: View {
                 NavigationLink(destination: NiceButtonExampleView()) {
                     Text("Nice Button")
                 }
+                NavigationLink(destination: AsyncImageExampleView()) {
+                    Text("Async Image Example")
+                }
                 NavigationLink(destination: SampleSignInView()) {
                     Text("Sign In")
                 }

--- a/NiceComponentsExample/NiceComponentsExample/View/AllComponentsView.swift
+++ b/NiceComponentsExample/NiceComponentsExample/View/AllComponentsView.swift
@@ -52,7 +52,7 @@ struct AllComponentsView: View {
                     Spacer()
                 }
 
-                ResizableImage(URL(string: "https://placekitten.com/200/300"), width: 200, height: 300)
+                ResizableImage(URL(string: "https://placekitten.com/200/300"), maxWidth: 200, maxHeight: 300)
             }
         }.padding(Layout.Spacing.standard)
     }

--- a/NiceComponentsExample/NiceComponentsExample/View/AsyncImageExampleView.swift
+++ b/NiceComponentsExample/NiceComponentsExample/View/AsyncImageExampleView.swift
@@ -1,0 +1,35 @@
+//
+//  AsyncImageExampleView.swift
+//  NiceComponentsExample
+//
+//  Created by Alejandro Zielinsky on 2022-08-10.
+//
+
+import NiceComponents
+import SwiftUI
+
+struct AsyncImageExampleView: View {
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .center, spacing: Layout.Spacing.medium) {
+                VStack {
+                    BodyText("Loading Image...")
+                    ResizableImage(URL(string: "https://placekitten.com/200/300"), maxWidth: 200, maxHeight: 300)
+                }
+                VStack {
+                    BodyText("Loading image icon with color placeholder")
+                    ResizableImage(URL(string: "https://placekitten.com/48/48"), maxWidth: 60, maxHeight: 60) {
+                        Color(
+                            red: .random(in: 0...1),
+                            green: .random(in: 0...1),
+                            blue: .random(in: 0...1)
+                        )
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(Layout.Spacing.standard)
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -12,15 +12,9 @@ let package = Package(
             name: "NiceComponents",
             targets: ["NiceComponents"]),
     ],
-    dependencies: [
-        .package(
-            url: "https://github.com/onevcat/Kingfisher.git",
-            from: "7.2.0"
-        )
-    ],
     targets: [
         .target(
-            name: "NiceComponents",
-            dependencies: ["Kingfisher"]),
+            name: "NiceComponents"
+        ),
     ]
 )

--- a/Sources/NiceComponents/Button/BorderlessButton.swift
+++ b/Sources/NiceComponents/Button/BorderlessButton.swift
@@ -13,8 +13,8 @@ public struct BorderlessButton: NiceButton {
     public let action: () -> Void
     public let inactive: Bool
 
-    public var leftImage: ResizableImage?
-    public var rightImage: ResizableImage?
+    public var leftImage: LocalResizableImage?
+    public var rightImage: LocalResizableImage?
     public var rightImageOffset: CGFloat?
     public var leftImageOffset: CGFloat?
 

--- a/Sources/NiceComponents/Button/DestructiveButton.swift
+++ b/Sources/NiceComponents/Button/DestructiveButton.swift
@@ -13,8 +13,8 @@ public struct DestructiveButton: NiceButton {
     public let action: () -> Void
     public let inactive: Bool
 
-    public var leftImage: ResizableImage?
-    public var rightImage: ResizableImage?
+    public var leftImage: LocalResizableImage?
+    public var rightImage: LocalResizableImage?
     public var rightImageOffset: CGFloat?
     public var leftImageOffset: CGFloat?
 

--- a/Sources/NiceComponents/Button/PrimaryButton.swift
+++ b/Sources/NiceComponents/Button/PrimaryButton.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+public typealias LocalResizableImage = ResizableImage<EmptyView>
+
 public struct PrimaryButton: NiceButton {
 
     public let text: String
@@ -14,8 +16,8 @@ public struct PrimaryButton: NiceButton {
     public let action: () -> Void
     public let inactive: Bool
 
-    public var leftImage: ResizableImage?
-    public var rightImage: ResizableImage?
+    public var leftImage: LocalResizableImage?
+    public var rightImage: LocalResizableImage?
     public var rightImageOffset: CGFloat?
     public var leftImageOffset: CGFloat?
 

--- a/Sources/NiceComponents/Button/SecondaryButton.swift
+++ b/Sources/NiceComponents/Button/SecondaryButton.swift
@@ -14,8 +14,8 @@ public struct SecondaryButton: NiceButton {
     public let action: () -> Void
     public let inactive: Bool
 
-    public var leftImage: ResizableImage?
-    public var rightImage: ResizableImage?
+    public var leftImage: LocalResizableImage?
+    public var rightImage: LocalResizableImage?
     public var rightImageOffset: CGFloat?
     public var leftImageOffset: CGFloat?
 

--- a/Sources/NiceComponents/Components/NiceButton.swift
+++ b/Sources/NiceComponents/Components/NiceButton.swift
@@ -16,13 +16,13 @@ public protocol NiceButton: View {
     static var defaultStyle: NiceButtonStyle { get }
     @ViewBuilder var defaultBody: DefaultBody { get }
 
-    var leftImage: ResizableImage? { get set }
-    var rightImage: ResizableImage? { get set }
+    var leftImage: LocalResizableImage? { get set }
+    var rightImage: LocalResizableImage? { get set }
     var leftImageOffset: CGFloat? { get set }
     var rightImageOffset: CGFloat? { get set }
 
-    mutating func addLeftImage(_ image: ResizableImage?, spacing: CGFloat)
-    mutating func addRightImage(_ image: ResizableImage?, spacing: CGFloat)
+    mutating func addLeftImage(_ image: LocalResizableImage?, spacing: CGFloat)
+    mutating func addRightImage(_ image: LocalResizableImage?, spacing: CGFloat)
 
     init(
         _ text: String,
@@ -121,23 +121,23 @@ extension NiceButton {
 
 public extension NiceButton {
 
-    mutating func addLeftImage(_ image: ResizableImage?, spacing: CGFloat) {
+    mutating func addLeftImage(_ image: LocalResizableImage?, spacing: CGFloat) {
         self.leftImage = image
         self.leftImageOffset = spacing
     }
 
-    mutating func addRightImage(_ image: ResizableImage?, spacing: CGFloat) {
+    mutating func addRightImage(_ image: LocalResizableImage?, spacing: CGFloat) {
         self.rightImage = image
         self.rightImageOffset = spacing
     }
 
-    func withLeftImage(_ image: ResizableImage?, spacing: CGFloat = 8.0) -> Self {
+    func withLeftImage(_ image: LocalResizableImage?, spacing: CGFloat = 8.0) -> Self {
         var copy = self
         copy.addLeftImage(image, spacing: spacing)
         return copy
     }
 
-    func withRightImage(_ image: ResizableImage?, spacing: CGFloat = 8.0) -> Self {
+    func withRightImage(_ image: LocalResizableImage?, spacing: CGFloat = 8.0) -> Self {
         var copy = self
         copy.addRightImage(image, spacing: spacing)
         return copy


### PR DESCRIPTION
### For #33 


This PR removes the KingFisher dependency in favour of `AsyncImage` and improves upon how we handle async images.
Removed hardcoded sizing for images fetched from URLs. Removed hardcoded contentMode for images. ( Now defaulting to .aspectFit). `ResizableImage` now take a generic view for the placeholder view when loading an async image. The default placeholder is an empty `LoadingView`. 

Due to the usage of generics, I created a LocalResizableImage typealias for any non-async ResizableImage that is now being referenced in places that depend on ResizableImages. This causes NiceButtons left/right images to now only support local images.  This is a constraint I don't believe should affect us at the moment, but is worth being aware of and addressed in the future. 

https://user-images.githubusercontent.com/17748596/184031790-7a3551dd-a8c5-4581-a3f9-293dd72f466b.MP4


