### PR TITLE
ResizableImage Error handling

### DIFF
--- a/Sources/NiceComponents/Components/ResizableImage.swift
+++ b/Sources/NiceComponents/Components/ResizableImage.swift
@@ -63,7 +63,7 @@ public struct ResizableImage: View {
         width: CGFloat,
         height: CGFloat,
         tintColor: Color? = nil,
-        fallbackImage: UIImage? = nil,
+        fallbackImage: String? = nil,
         contentMode: SwiftUI.ContentMode = .fit,
         loadingStyle: UIActivityIndicatorView.Style? = nil
     ) {
@@ -75,7 +75,11 @@ public struct ResizableImage: View {
         self.contentMode = contentMode
         self.tintColor = tintColor
         self.loadingStyle = loadingStyle
-        self.fallbackImage = fallbackImage
+        if let imageName = fallbackImage {
+            self.fallbackImage = UIImage(named: imageName)
+        } else {
+            self.fallbackImage = nil
+        }
     }
 
     private var image: Image? {


### PR DESCRIPTION
This PR fixes a bug where ResizableImage would load forever if an image fetch from a URL threw an error.
ResizableImage now allows us to pass in a fallback image incase of an error. If no fallback is specified the loading spinner stops and no view is rendered. 

Usage: 
``` Swift
ResizableImage(
    URL(string: "https://placekitten.com/50/50"), 
    width: 100, 
    height: 100, 
    fallbackImage: "placeholder", 
    contentMode: .fill,
    loadingStyle: .medium
)
```

https://user-images.githubusercontent.com/17748596/184228400-27e0414b-3b22-450c-bf7b-194b322469d2.mov


