### PR TITLE
add dynamic type support, if and iflet view builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0]
+- Add functionality to NiceText to allow setting a maximum dynamic type font size
+- Add two helper functions to `View`, `if` and `iflet` that allow for optional view modifying
+
 ## [0.4.0] - 2022-07-22
 - Reworked stateful view
 - ResizeableImage now supports loading / fallbackImage 

--- a/NiceComponentsExample/NiceComponentsExample.xcodeproj/project.pbxproj
+++ b/NiceComponentsExample/NiceComponentsExample.xcodeproj/project.pbxproj
@@ -336,7 +336,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2;
+				MARKETING_VERSION = 0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.steamclock.NiceComponentsExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -359,7 +359,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2;
+				MARKETING_VERSION = 0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.steamclock.NiceComponentsExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/NiceComponentsExample/NiceComponentsExample/View/AllComponentsView.swift
+++ b/NiceComponentsExample/NiceComponentsExample/View/AllComponentsView.swift
@@ -14,7 +14,9 @@ struct AllComponentsView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 5) {
                 VStack(alignment: .leading, spacing: 2) {
-                    ScreenTitle("Screen Title")
+                    ScreenTitle("Screen Title", style: Config.current.sectionTitleStyle.with(
+                        dynamicTypeMaxSize: .accessibility4
+                    ))
                     SectionTitle("Section Title")
                     ItemTitle("Item Title")
                     ItemTitle("Attributed Item Title") { string  in

--- a/Sources/NiceComponents/Components/NiceButton.swift
+++ b/Sources/NiceComponents/Components/NiceButton.swift
@@ -77,7 +77,12 @@ extension NiceButton {
                 }
                 Text(text)
                     .foregroundColor(inactive ? style.disabledOnSurfaceColor : style.onSurfaceColor)
-                    .scaledFont(name: style.textStyle.name, size: style.textStyle.size, weight: style.textStyle.weight)
+                    .scaledFont(
+                        name: style.textStyle.name,
+                        size: style.textStyle.size,
+                        weight: style.textStyle.weight,
+                        maxSize: style.textStyle.dynamicTypeMaxSize
+                    )
                     .padding(.leading, leftImageOffset)
                     .padding(.trailing, rightImageOffset)
                 if let rightImage = rightImage {

--- a/Sources/NiceComponents/Components/NiceText.swift
+++ b/Sources/NiceComponents/Components/NiceText.swift
@@ -17,7 +17,7 @@ public protocol NiceText: View {
 
     init(_ text: String, style: TypeStyle?)
 
-    init(_ text: String, color: Color?, size: CGFloat?, lineLimit: Int?)
+    init(_ text: String, color: Color?, size: CGFloat?, lineLimit: Int?, dynamicMaxSize: DynamicTypeSize?)
 
     init(_ text: String, configure: (inout AttributedString) -> Void)
 }
@@ -28,14 +28,16 @@ public extension NiceText {
         _ text: String,
         color: Color? = nil,
         size: CGFloat? = nil,
-        lineLimit: Int? = nil
+        lineLimit: Int? = nil,
+        dynamicMaxSize: DynamicTypeSize? = nil
     ) {
         self.init(
             text,
             style: Self.defaultStyle.with(
                 color: color,
                 size: size,
-                lineLimit: lineLimit
+                lineLimit: lineLimit,
+                dynamicTypeMaxSize: dynamicMaxSize
             )
         )
     }

--- a/Sources/NiceComponents/Helper/DynamicTypeSize+MaxSize.swift
+++ b/Sources/NiceComponents/Helper/DynamicTypeSize+MaxSize.swift
@@ -1,0 +1,29 @@
+//
+//  DynamicTypeSize+MaxSize.swift
+//  
+//
+//  Created by Brendan on 2022-08-12.
+//
+
+import SwiftUI
+
+extension DynamicTypeSize {
+    var maxFontSize: CGFloat? {
+        switch self {
+        case .xSmall: return 30
+        case .small: return 31
+        case .medium: return 32
+        case .large: return 34
+        case .xLarge: return 37
+        case .xxLarge: return 40
+        case .xxxLarge: return 45
+        case .accessibility1: return 52
+        case .accessibility2: return 62
+        case .accessibility3: return 74
+        case .accessibility4: return 86
+        case .accessibility5: return 96
+        @unknown default:
+            return nil
+        }
+    }
+}

--- a/Sources/NiceComponents/Helper/DynamicTypeSize+MaxSize.swift
+++ b/Sources/NiceComponents/Helper/DynamicTypeSize+MaxSize.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 extension DynamicTypeSize {
+    // These values were determined based on the iOS accessibility settings on iOS 16.0
     var maxFontSize: CGFloat? {
         switch self {
         case .xSmall: return 30

--- a/Sources/NiceComponents/Helper/ScaledFont.swift
+++ b/Sources/NiceComponents/Helper/ScaledFont.swift
@@ -13,9 +13,14 @@ public struct ScaledFont: ViewModifier {
     var name: String?
     var weight: Font.Weight
     var size: CGFloat
+    var maxSize: DynamicTypeSize?
 
     public func body(content: Content) -> some View {
-       let scaledSize = UIFontMetrics.default.scaledValue(for: size)
+        var scaledSize = UIFontMetrics.default.scaledValue(for: size)
+
+        if let maxFontSize = maxSize?.maxFontSize {
+            scaledSize = min(maxFontSize, scaledSize)
+        }
         if let name = name {
             return content.font(.custom(name, size: scaledSize))
         }
@@ -26,7 +31,7 @@ public struct ScaledFont: ViewModifier {
 
 @available(iOS 13, macCatalyst 13, tvOS 13, watchOS 6, *)
 extension View {
-    public func scaledFont(name: String?, size: CGFloat, weight: Font.Weight?) -> some View {
-        return self.modifier(ScaledFont(name: name, weight: weight ?? .medium, size: size))
+    public func scaledFont(name: String?, size: CGFloat, weight: Font.Weight?, maxSize: DynamicTypeSize? = nil) -> some View {
+        return self.modifier(ScaledFont(name: name, weight: weight ?? .medium, size: size, maxSize: maxSize))
     }
 }

--- a/Sources/NiceComponents/Helper/View+If.swift
+++ b/Sources/NiceComponents/Helper/View+If.swift
@@ -1,0 +1,29 @@
+//
+//  View+If.swift
+//  
+//
+//  Created by Brendan on 2022-08-12.
+//
+
+import SwiftUI
+
+// https://stackoverflow.com/a/62962375
+public extension View {
+    @ViewBuilder
+    func `if`<Transform: View>(_ condition: Bool, transform: (Self) -> Transform) -> some View {
+        if condition {
+            transform(self)
+        } else {
+            self
+        }
+    }
+
+    @ViewBuilder func iflet<Content: View, T>(_ conditional: Optional<T>, @ViewBuilder _ content: (Self, _ value: T) -> Content) -> some View {
+        if let value = conditional {
+            content(self, value)
+        } else {
+            self
+        }
+    }
+}
+

--- a/Sources/NiceComponents/Text/BodyText.swift
+++ b/Sources/NiceComponents/Text/BodyText.swift
@@ -23,7 +23,12 @@ public struct BodyText: NiceText {
     public var body: some View {
         Text(text)
             .foregroundColor(style.color)
-            .scaledFont(name: style.theme.name, size: style.theme.size, weight: style.theme.weight)
+            .scaledFont(
+                name: style.theme.name,
+                size: style.theme.size,
+                weight: style.theme.weight,
+                maxSize: style.theme.dynamicTypeMaxSize
+            )
             .fixedSize(horizontal: false, vertical: true)
             .lineLimit(style.lineLimit)
     }

--- a/Sources/NiceComponents/Text/DetailText.swift
+++ b/Sources/NiceComponents/Text/DetailText.swift
@@ -23,7 +23,12 @@ public struct DetailText: NiceText {
     public var body: some View {
         Text(text)
             .foregroundColor(style.color)
-            .scaledFont(name: style.theme.name, size: style.theme.size, weight: style.theme.weight)
+            .scaledFont(
+                name: style.theme.name,
+                size: style.theme.size,
+                weight: style.theme.weight,
+                maxSize: style.theme.dynamicTypeMaxSize
+            )
             .fixedSize(horizontal: false, vertical: true)
             .lineLimit(style.lineLimit)
     }

--- a/Sources/NiceComponents/Theme/TypeStyle.swift
+++ b/Sources/NiceComponents/Theme/TypeStyle.swift
@@ -22,13 +22,14 @@ public struct TypeStyle {
 }
 
 public extension TypeStyle {
-    func with(color: Color? = nil, size: CGFloat? = nil, lineLimit: Int? = nil) -> TypeStyle {
+    func with(color: Color? = nil, size: CGFloat? = nil, lineLimit: Int? = nil, dynamicTypeMaxSize: DynamicTypeSize? = nil) -> TypeStyle {
         TypeStyle(
             color: color ?? self.color,
             theme: TypeTheme.TextStyle(
                 self.theme.name,
                 size: size ?? self.theme.size,
-                weight: self.theme.weight
+                weight: self.theme.weight,
+                dynamicTypeMaxSize: dynamicTypeMaxSize
             ),
             lineLimit: lineLimit ?? self.lineLimit
         )

--- a/Sources/NiceComponents/Theme/TypeTheme.swift
+++ b/Sources/NiceComponents/Theme/TypeTheme.swift
@@ -15,10 +15,11 @@ public struct TypeTheme {
         public var dynamicTypeMaxSize: DynamicTypeSize?
 
         public init(
-                _ name: String? = nil,
-                size: CGFloat,
-                weight: Font.Weight? = nil,
-                dynamicTypeMaxSize: DynamicTypeSize? = nil) {
+            _ name: String? = nil,
+            size: CGFloat,
+            weight: Font.Weight? = nil,
+            dynamicTypeMaxSize: DynamicTypeSize? = nil
+        ) {
             self.name = name
             self.size = size
             self.weight = weight

--- a/Sources/NiceComponents/Theme/TypeTheme.swift
+++ b/Sources/NiceComponents/Theme/TypeTheme.swift
@@ -12,11 +12,17 @@ public struct TypeTheme {
         public let name: String?
         public let weight: Font.Weight?
         public let size: CGFloat
+        public var dynamicTypeMaxSize: DynamicTypeSize?
 
-        public init(_ name: String? = nil, size: CGFloat, weight: Font.Weight? = nil) {
+        public init(
+                _ name: String? = nil,
+                size: CGFloat,
+                weight: Font.Weight? = nil,
+                dynamicTypeMaxSize: DynamicTypeSize? = nil) {
             self.name = name
             self.size = size
             self.weight = weight
+            self.dynamicTypeMaxSize = dynamicTypeMaxSize
         }
     }
 

--- a/Sources/NiceComponents/Title/ItemTitle.swift
+++ b/Sources/NiceComponents/Title/ItemTitle.swift
@@ -24,7 +24,12 @@ public struct ItemTitle: NiceText {
     public var body: some View {
         Text(text)
             .foregroundColor(style.color)
-            .scaledFont(name: style.theme.name, size: style.theme.size, weight: style.theme.weight)
+            .scaledFont(
+                name: style.theme.name,
+                size: style.theme.size,
+                weight: style.theme.weight,
+                maxSize: style.theme.dynamicTypeMaxSize
+            )
             .fixedSize(horizontal: false, vertical: true)
             .lineLimit(style.lineLimit)
     }

--- a/Sources/NiceComponents/Title/ScreenTitle.swift
+++ b/Sources/NiceComponents/Title/ScreenTitle.swift
@@ -23,7 +23,12 @@ public struct ScreenTitle: NiceText {
     public var body: some View {
         Text(text)
             .foregroundColor(style.color)
-            .scaledFont(name: style.theme.name, size: style.theme.size, weight: style.theme.weight)
+            .scaledFont(
+                name: style.theme.name,
+                size: style.theme.size,
+                weight: style.theme.weight,
+                maxSize: style.theme.dynamicTypeMaxSize
+            )
             .fixedSize(horizontal: false, vertical: true)
             .lineLimit(style.lineLimit)
     }

--- a/Sources/NiceComponents/Title/SectionTitle.swift
+++ b/Sources/NiceComponents/Title/SectionTitle.swift
@@ -24,7 +24,12 @@ public struct SectionTitle: NiceText {
     public var body: some View {
         Text(text)
             .foregroundColor(style.color)
-            .scaledFont(name: style.theme.name, size: style.theme.size, weight: style.theme.weight)
+            .scaledFont(
+                name: style.theme.name,
+                size: style.theme.size,
+                weight: style.theme.weight,
+                maxSize: style.theme.dynamicTypeMaxSize
+            )
             .fixedSize(horizontal: false, vertical: true)
             .lineLimit(style.lineLimit)
     }


### PR DESCRIPTION
This PR adds two new features:

1. Support for specifying a maximum font size, to be applied for users with a dynamic type setting. When adding support for dynamic type, while it's generally not great to ignore dynamic type, there are some situations where it's necessary, like text in tab bars, etc. This allows users to set a maximum font size when creating text that allows them to limit how large text can be.

2. Adds `if` and `iflet` view modifiers to `View`. While not strictly required, these modifiers are immensely helpful, and like StatefulView IMO land in the category of "helpful SwiftUI stuff that we'll likely want in future projects". As such, it would be nice to just include them here.  