### PR TITLE
Set default padding of NiceButton content to zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2]
+- Fixed padding of NiceButton with image.
+
 ## [1.1.1]
 - Updated cornerRadius handling for buttons
 

--- a/Sources/NiceComponents/Button/NiceButton.swift
+++ b/Sources/NiceComponents/Button/NiceButton.swift
@@ -129,8 +129,8 @@ extension NiceButton {
                         weight: style.fontStyle.weight,
                         maxSize: style.fontStyle.dynamicTypeMaxSize
                     )
-                    .padding(.leading, leftImageOffset)
-                    .padding(.trailing, rightImageOffset)
+                    .padding(.leading, leftImageOffset ?? 0)
+                    .padding(.trailing, rightImageOffset ?? 0)
                 if let rightImage = rightImage {
                     rightImage
                 }


### PR DESCRIPTION
If only one Image was added to a button, the default padding on the other side pushes the content off center. This PR sets the default padding to 0 if no Image was added to a NiceButton.